### PR TITLE
Get .css files in html file relative to passed html file path

### DIFF
--- a/hackproject/code/src/app.ts
+++ b/hackproject/code/src/app.ts
@@ -10,7 +10,8 @@ const main = async () => {
     if (process.argv.includes("--html")) {
       htmlFile = getFileLocation(FileType.HTML);
     }
-    const html = await file.read(path.join(rootPath, htmlFile));
+    const htmlPath = path.join(rootPath, htmlFile);
+    const html = await file.read(htmlPath);
 
     let css = "";
     if (process.argv.includes("--css")) {
@@ -18,7 +19,7 @@ const main = async () => {
       css = await file.read(path.join(rootPath, cssFile));
     }
 
-    css += await getCss(html);
+    css += await getCss(html, htmlPath);
 
     const dom = new JSDOM(html, {
       runScripts: "dangerously",
@@ -30,17 +31,15 @@ const main = async () => {
     dom.window.onload = () => {
       const body = dom.window.document.querySelector("body");
       const requirement = Requirement.AA;
-  
+
       const validator = new ContrastValidator();
       if (!validator.validate(dom, body, requirement)) {
         console.log("\x1b[31m accessibility test failed!\x1b[0m");
         process.exit(1);
-      } 
+      }
       console.log("\x1b[32m accessibility test passed!\x1b[0m");
       process.exit(0);
-
     };
-    
   } catch (error) {
     if (error instanceof FileNotSpecified) {
       console.error(error.message);

--- a/hackproject/code/src/utils/getCss.ts
+++ b/hackproject/code/src/utils/getCss.ts
@@ -1,6 +1,14 @@
 import fs from "fs/promises";
-import BASE_PATH from "./srcPath";
 import path from "path";
+
+const isFilePath = (str: string): boolean => {
+  try {
+    new URL(str);
+    return false;
+  } catch (_) {
+    return true;
+  }
+};
 
 const getCssPaths = (html: string): string[] => {
   const pattern = /<link\s+(?:[^>]*?\s+)?href=(["'])(.*?)\1/gm;
@@ -8,16 +16,17 @@ const getCssPaths = (html: string): string[] => {
 
   if (!matches) return [];
 
-  const paths = Array.from(matches, (m) => m[2]);
+  const paths = Array.from(matches, (m) => m[2]).filter((p) => isFilePath(p));
   return [...paths];
 };
 
-const getCss = async (html: string): Promise<string> => {
+const getCss = async (html: string, htmlPath: string): Promise<string> => {
   const cssPaths = getCssPaths(html);
+  const basePath = path.dirname(htmlPath);
 
   let css = "";
   for (const cssPath of cssPaths) {
-    const absolutePath = path.join(BASE_PATH, cssPath);
+    const absolutePath = path.join(basePath, cssPath);
 
     try {
       const data = await fs.readFile(absolutePath, { encoding: "utf-8" });

--- a/hackproject/code/static/sample.html
+++ b/hackproject/code/static/sample.html
@@ -5,8 +5,14 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Document</title>
-    <link rel="stylesheet" href="./static/style.css" />
-    <link rel="stylesheet" href="./static/demo.css" />
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="demo.css" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ"
+      crossorigin="anonymous"
+    />
   </head>
   <body>
     <section>


### PR DESCRIPTION
Users no longer need to include './static/style.css' in the HTML file; they can simply use 'style.css'. In addition, the program only allows the use of CSS files stored on the user's computer and does not support external CSS files.